### PR TITLE
feat: add new ergonomic entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ RUN LLVM_CONFIG=/usr/bin/llvm-config-10 python -m pip install --requirement /tmp
 
 RUN mkdir /workspace
 WORKDIR /workspace
-CMD python
+COPY entrypoint.py /entrypoint.py
+ENTRYPOINT ["/entrypoint.py"]

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import sys
+from pathlib import Path
+
+executable = os.environ.get("ACTION_EXEC", "python")
+exe_path = shutil.which(executable)
+args = sys.argv[1:]
+
+if len(sys.argv) > 1:
+    path = shutil.which(sys.argv[1])
+    # special case - the user has provided their own valid executable as the
+    # first argument, so switch to executing that
+    if path is not None:
+        exe_path = path
+        args = sys.argv[2:]
+
+
+if os.environ.get("ENTRYPOINT_TESTING"):
+    print([exe_path] + args)
+else:
+    os.execve(exe_path, [exe_path] + args, os.environ)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,35 @@
+import os
+import subprocess
+
+import pytest
+
+
+def test_bare_python():
+    env = os.environ.copy()
+    env["ENTRYPOINT_TESTING"] = "1"
+    cmd = ["/entrypoint.py"]
+    ps = subprocess.run(cmd, check=True, capture_output=True, env=env)
+    assert ps.stdout.strip() == b"['/usr/bin/python']"
+
+
+def test_python_args():
+    cmd = ["/entrypoint.py", "-c", "print('test')"]
+    ps = subprocess.run(cmd, check=True, capture_output=True)
+    assert ps.stdout.strip() == b"test"
+
+
+def test_exec_with_args():
+    cmd = ["/entrypoint.py", "bash", "-c", "echo test"]
+    ps = subprocess.run(cmd, check=True, capture_output=True)
+    assert ps.stdout.strip() == b"test"
+
+
+def test_python_script(tmp_path):
+    script = tmp_path / "test.py"
+    script.write_text("import sys; print(sys.argv)")
+
+    cmd = ["/entrypoint.py", script, "a", "-b", "--arg"]
+    ps = subprocess.run(cmd, check=True, capture_output=True)
+    # this means it ran: python {script} ...
+    expected = f"['{script}', 'a', '-b', '--arg']".encode("utf8")
+    assert ps.stdout.strip() == expected


### PR DESCRIPTION
Previously, we just use CMD ["python"] in the Dockerfile. This allowed
users to override commands, e.g. run other python tools. But it meant
the common case of running a python script needed extra e.g.
`action: python:latest python myscript.py`.

This change adds an entrypoint that is smart enough to allow arbitrary
CMD args, but also skip the superfluous python, while remaning backwards
compatible.

So a user can now write:

`action: python:latest myscript.py ...`

or

`action: python:latest python myscript.py ...`

or

`action: python:latest other-executable ...`

and it all just works.