### PR TITLE
feat: refactor Dockerfile for cleaner image

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -11,9 +11,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Build image
-      run: make build IMAGE_NAME=$IMAGE_NAME
+      run: make build
     - name: Run tests
-      run: make test IMAGE_NAME=$IMAGE_NAME
+      run: make test
+    - name: Run lint
+      run: make lint 
     - name: Log into GitHub Container Registry
       run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
     - name: Push image to GitHub Container Registry

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Build image
-      run: make build IMAGE_NAME=$IMAGE_NAME
+      run: make build
     - name: Run tests
-      run: make test IMAGE_NAME=$IMAGE_NAME
+      run: make test
+    - name: Run lint
+      run: make lint 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ FROM base-python as python
 
 # Some static metadata for this specific image, as defined by:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
+# The org.opensafely.action label is used by the jobrunner to indicate this is
+# an approved action image to run.
 LABEL org.opencontainers.image.title="python" \
       org.opencontainers.image.description="Python action for opensafely.org" \
       org.opencontainers.image.source="https://github.com/opensafely-core/python-docker" \
@@ -57,7 +59,7 @@ ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH" ACTION_EXEC=python
 RUN mkdir /workspace
 WORKDIR /workspace
 
-# tag with build info
+# tag with build info as the very last step, as it will never be cached
 ARG BUILD_DATE
 ARG GITREF
 LABEL org.opencontainers.image.created=$BUILD_DATE org.opencontainers.image.revision=$GITREF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,52 @@
-FROM ghcr.io/opensafely/base-docker
+#################################################
+#
+# First build a base python image from the OS base image, so we only do this once.
+FROM ghcr.io/opensafely-core/base-docker as base-python
+COPY dependencies.txt .
+# use space efficient utility from base image
+RUN /root/docker-apt-install.sh dependencies.txt
 
-RUN apt-get update --fix-missing
+#################################################
+#
+# Next, use that to create a build image
+FROM base-python as builder
 
-# For numba
-RUN apt-get install -y llvm-10 llvm-10-dev
+# install build time dependencies 
+COPY build-dependencies.txt .
+RUN /root/docker-apt-install.sh build-dependencies.txt
 
-RUN apt-get install -y python3.8 python3.8-dev python3-pip
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
+# install everything in venv for isolation from system python libraries
+RUN python3 -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH" LLVM_CONFIG=/usr/bin/llvm-config-10
 
-# Install pip requirements
-COPY requirements.txt /tmp/
-RUN LLVM_CONFIG=/usr/bin/llvm-config-10 python -m pip install --requirement /tmp/requirements.txt
+COPY requirements.txt .
+# We ensure up-to-date build tools
+# Note: the mount command does two things: 1) caches across builds to speed up
+# local development and 2) ensures the pip cache does not get committed to the
+# layer.
+RUN python -m pip install -U pip setuptools wheel && \
+    python -m pip install --requirement requirements.txt
+
+################################################
+#
+# Finally, build the actual image from the base-python image
+FROM base-python as python
+
+# Some static metadata for this specific image
+LABEL org.label-schema.name="python" \
+      org.label-schema.description="Python action for opensafely.org" \
+      org.label-schema.vcs-url="https://github.com/opensafely-core/python-docker" \
+      org.opensafely.action="python"
+
+# copy venv over from builder image
+COPY --from=builder /opt/venv /opt/venv
+# ACTION_EXEC is the default entrypoint executable
+ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH" ACTION_EXEC=python
 
 RUN mkdir /workspace
 WORKDIR /workspace
-CMD python
+
+# tag with build info
+ARG BUILD_DATE
+ARG GITREF
+LABEL org.label-schema.build-date=$BUILD_DATE org.label-schema.vcs-ref=$GITREF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.2
 #################################################
 #
 # First build a base python image from the OS base image, so we only do this once.
@@ -24,7 +25,8 @@ COPY requirements.txt .
 # Note: the mount command does two things: 1) caches across builds to speed up
 # local development and 2) ensures the pip cache does not get committed to the
 # layer.
-RUN python -m pip install -U pip setuptools wheel && \
+RUN --mount=type=cache,target=/root/.cache \
+    python -m pip install -U pip setuptools wheel && \
     python -m pip install --requirement requirements.txt
 
 ################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,57 @@
 # syntax=docker/dockerfile:1.2
 #################################################
 #
-# First build a base python image from the OS base image, so we only do this once.
-FROM ghcr.io/opensafely-core/base-docker as base-python
-COPY dependencies.txt .
+# We need base python dependencies on both the builder and python images, so
+# create base image with those installed to save installing them twice.
+#
+# DL3007 ignored because base-docker a) doesn't have any other tags currently,
+# and b) we specifically always want to build on the latest base image, by
+# design.
+#
+# hadolint ignore=DL3007
+FROM ghcr.io/opensafely-core/base-docker:latest as base-python
+COPY dependencies.txt /root/dependencies.txt
 # use space efficient utility from base image
-RUN /root/docker-apt-install.sh dependencies.txt
+RUN /root/docker-apt-install.sh /root/dependencies.txt
 
 #################################################
 #
-# Next, use that to create a build image
+# Next, use the base-docker-plus-python image to create a build image
 FROM base-python as builder
 
 # install build time dependencies 
-COPY build-dependencies.txt .
-RUN /root/docker-apt-install.sh build-dependencies.txt
+COPY build-dependencies.txt /root/build-dependencies.txt
+RUN /root/docker-apt-install.sh /root/build-dependencies.txt
 
 # install everything in venv for isolation from system python libraries
 RUN python3 -m venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH" LLVM_CONFIG=/usr/bin/llvm-config-10
 
-COPY requirements.txt .
-# We ensure up-to-date build tools
+COPY requirements.txt /root/requirements.txt
+# We ensure up-to-date build tools (which why we ignore DL3013)
 # Note: the mount command does two things: 1) caches across builds to speed up
 # local development and 2) ensures the pip cache does not get committed to the
-# layer.
+# layer (which is why we ignore DL3042).
+# hadolint ignore=DL3013,DL3042
 RUN --mount=type=cache,target=/root/.cache \
     python -m pip install -U pip setuptools wheel && \
-    python -m pip install --requirement requirements.txt
+    python -m pip install --requirement /root/requirements.txt
 
 ################################################
 #
 # Finally, build the actual image from the base-python image
 FROM base-python as python
 
-# Some static metadata for this specific image
-LABEL org.label-schema.name="python" \
-      org.label-schema.description="Python action for opensafely.org" \
-      org.label-schema.vcs-url="https://github.com/opensafely-core/python-docker" \
+# Some static metadata for this specific image, as defined by:
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
+LABEL org.opencontainers.image.title="python" \
+      org.opencontainers.image.description="Python action for opensafely.org" \
+      org.opencontainers.image.source="https://github.com/opensafely-core/python-docker" \
       org.opensafely.action="python"
 
 # copy venv over from builder image
 COPY --from=builder /opt/venv /opt/venv
-# ACTION_EXEC is the default entrypoint executable
+# ACTION_EXEC sets the default executable for the entrypoint in the base-docker image
 ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH" ACTION_EXEC=python
 
 RUN mkdir /workspace
@@ -51,4 +60,4 @@ WORKDIR /workspace
 # tag with build info
 ARG BUILD_DATE
 ARG GITREF
-LABEL org.label-schema.build-date=$BUILD_DATE org.label-schema.vcs-ref=$GITREF
+LABEL org.opencontainers.image.created=$BUILD_DATE org.opencontainers.image.revision=$GITREF

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ test:
 	docker run $(RUN_ARGS) --rm -v $(PWD):/workspace $(IMAGE_NAME) pytest tests -v
 
 
+.PHONY: lint
+lint:
+	@docker pull hadolint/hadolint
+	@docker run --rm -i hadolint/hadolint < Dockerfile
+
 requirements.txt: requirements.in venv/bin/pip-compile
 	venv/bin/pip-compile requirements.in
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 IMAGE_NAME ?= docker-python-test
 INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
+export DOCKER_BUILDKIT=1
 
 .PHONY: build
 build: BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
 build: GITREF=$(shell git rev-parse --short HEAD)
 build:
 	docker build . --tag $(IMAGE_NAME) \
+		--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/opensafely-core/python \
 		--build-arg BUILD_DATE=$(BUILD_DATE) --build-arg GITREF=$(GITREF)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,23 @@
 IMAGE_NAME ?= docker-python-test
 INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
 
+.PHONY: build
+build: BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
+build: GITREF=$(shell git rev-parse --short HEAD)
+build:
+	docker build . --tag $(IMAGE_NAME) \
+		--build-arg BUILD_DATE=$(BUILD_DATE) --build-arg GITREF=$(GITREF)
+
+
+.PHONY: test
+ifdef INTERACTIVE
+test: RUN_ARGS=-it
+else
+test: RUN_ARGS=
+endif
+test:
+	docker run $(RUN_ARGS) --rm -v $(PWD):/workspace $(IMAGE_NAME) pytest tests -v
+
 
 requirements.txt: requirements.in venv/bin/pip-compile
 	venv/bin/pip-compile requirements.in
@@ -11,15 +28,4 @@ venv/bin/pip-compile: | venv
 venv:
 	virtualenv -p python3 venv
 
-.PHONY: build
-build:
-	docker build . -t $(IMAGE_NAME)
 
-.PHONY: test
-ifdef INTERACTIVE
-test: RUN_ARGS=-it
-else
-test: RUN_ARGS=
-endif
-test: build
-	docker run $(RUN_ARGS) --rm -v $(PWD):/workspace $(IMAGE_NAME) pytest tests -v

--- a/build-dependencies.txt
+++ b/build-dependencies.txt
@@ -1,0 +1,8 @@
+# build time dependencies
+build-essential
+gcc
+python3-dev
+python3-venv
+python3-wheel
+# for numba
+llvm-10-dev

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,0 +1,8 @@
+# run time dependencies
+# ensure fully working base python3 installation
+# see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
+python3
+python3-pip
+python3-distutils
+tzdata
+ca-certificates

--- a/tests/test_numba.py
+++ b/tests/test_numba.py
@@ -1,0 +1,17 @@
+from numba import jit
+import numpy as np
+
+x = np.arange(100).reshape(10, 10)
+
+def test_numba():
+
+    @jit(nopython=True) # Set "nopython" mode for best performance, equivalent to @njit
+    def go_fast(a): # Function is compiled to machine code when called the first time
+        trace = 0.0
+        for i in range(a.shape[0]):   # Numba likes loops
+            trace += np.tanh(a[i, i]) # Numba likes NumPy functions
+        return a + trace              # Numba likes NumPy broadcasting
+
+    print(go_fast(x))
+
+


### PR DESCRIPTION
 - use multistage builder image to keep build deps out of final image
 - uses new base-docker features: entrypoint and docker-apt-install.sh
 - add build metadata
 - added numba test to make sure it worked, as it has complex deps
 - use buildkit for faster builds