### PR TITLE
feat: Require pyarrow

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,6 +18,7 @@ scipy
 tqdm
 numba
 opensafely-cohort-extractor
+pyarrow
 
 # Both these required for plotly+notebooks
 plotly

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements.in
 #
+appnope==0.1.2
+    # via
+    #   ipykernel
+    #   ipython
 attrs==19.3.0
     # via
     #   fiona
@@ -188,6 +192,7 @@ numpy==1.18.1
     #   numba
     #   pandas
     #   patsy
+    #   pyarrow
     #   scipy
     #   seaborn
     #   statsmodels
@@ -258,6 +263,8 @@ py==1.8.1
     # via
     #   pytest
     #   retry
+pyarrow==3.0.0
+    # via -r requirements.in
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8


### PR DESCRIPTION
cohort-extractor now supports binary output formats (opensafely-core/cohort-extractor#508), including feather files. However, Pandas requires pyarrow to read feather files. (Thankfully, Pandas reads the other binary output formats natively.)