### PR TITLE
Enable auto-merge on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "opensafely-core/developers"
     allow:
       - dependency-name: "opensafely-cohort-extractor"

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,0 +1,28 @@
+name: Dependabot auto-approve and enable auto-merge
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ test:
 
 .PHONY: lint
 lint:
-	@docker pull hadolint/hadolint
-	@docker run --rm -i hadolint/hadolint < Dockerfile
+	@docker pull hadolint/hadolint:v2.8.0
+	@docker run --rm -i hadolint/hadolint:v2.8.0 < Dockerfile
 
 requirements.txt: requirements.in venv/bin/pip-compile
 	venv/bin/pip-compile requirements.in


### PR DESCRIPTION
Note this is limited to updates for opensafely-cohort-extractor