### PR TITLE
rename action jobs

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -5,7 +5,7 @@ on:
 env:
   IMAGE_NAME: python
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,7 @@ on:
 env:
   IMAGE_NAME: python
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout


### PR DESCRIPTION
- add lifelines
- Upgrade opensafely-cohort-extractor to v1.61.1
- Add dependabot to check for cohort-extractor updates
- Add .python-version file for dependabot
- Bump opensafely-cohort-extractor from 1.61.1 to 1.61.3
- Bump opensafely-cohort-extractor from 1.61.3 to 1.62.1
- Bump opensafely-cohort-extractor from 1.62.1 to 1.62.4
- Enable auto-merge on dependabot PRs
- Pin hadolint image version Pin to the most recent version that doesn't fail Dockerfiles that start with # syntax = See https://github.com/hadolint/hadolint/issues/795
- Bump opensafely-cohort-extractor from 1.62.4 to 1.63.0
- Bump opensafely-cohort-extractor from 1.63.0 to 1.63.1
- Bump opensafely-cohort-extractor from 1.63.1 to 1.64.0
- Bump opensafely-cohort-extractor from 1.64.0 to 1.65.0
- Bump opensafely-cohort-extractor from 1.65.0 to 1.65.1
- Bump opensafely-cohort-extractor from 1.65.1 to 1.66.0
- Bump opensafely-cohort-extractor from 1.66.0 to 1.67.0
- Bump opensafely-cohort-extractor from 1.67.0 to 1.68.0
- Bump opensafely-cohort-extractor from 1.68.0 to 1.69.0
- Bump opensafely-cohort-extractor from 1.69.0 to 1.69.1
- Bump opensafely-cohort-extractor from 1.69.1 to 1.69.2
- Bump opensafely-cohort-extractor from 1.69.2 to 1.71.0
- Bump opensafely-cohort-extractor from 1.71.0 to 1.71.1
- Bump opensafely-cohort-extractor from 1.71.1 to 1.72.0
- rename action jobs to differentiate them better in action logs
