### PR TITLE
Enable workflow dispatch trigger on build and publish action

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -2,6 +2,7 @@ name: Build and publish
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 env:
   IMAGE_NAME: python
 jobs:


### PR DESCRIPTION
We have dependabot auto-merge set up for updates to opensafely-cohort-extractor only.  This doesn't trigger the build-and-publish action on merges, since it's using `GITHUB_TOKEN`.

The alternative is to [use a PAT](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token) but for now adding a workflow_dispatch trigger means we can at least manually build/publish after dependabot merges. 