### PR TITLE
fix: test basic execution patterns

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Build image
       run: make build
     - name: Run tests
-      run: make test
+      run: make test functional-test
     - name: Run lint
       run: make lint 
     - name: Log into GitHub Container Registry

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,6 @@ jobs:
     - name: Build image
       run: make build
     - name: Run tests
-      run: make test
+      run: make test functional-test
     - name: Run lint
       run: make lint 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ build:
 test:
 	docker-compose run --rm -v $(PWD):/workspace python pytest tests -v
 
+# test basic python invocation
+functional-test:
+	docker-compose run --rm python -c ''
+	docker-compose run --rm python python -c ''
+
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
This would have caught that the new base-action stuff did not work due
to the python on the path being a symlink.
