### PR TITLE
Remove opensafely-matching from v2 image

### DIFF
--- a/v2/packages.md
+++ b/v2/packages.md
@@ -90,7 +90,6 @@ It comes pre-installed with a standard set of python packages.
 - [numba: 0.58.1](https://pypi.org/project/numba/0.58.1/)
 - [numpy: 1.26.2](https://pypi.org/project/numpy/1.26.2/)
 - [opensafely-cohort-extractor: 1.90.0](https://pypi.org/project/opensafely-cohort-extractor/1.90.0/)
-- [opensafely-matching: 0.2.0](https://pypi.org/project/opensafely-matching/0.2.0/)
 - [overrides: 7.4.0](https://pypi.org/project/overrides/7.4.0/)
 - [packaging: 23.2](https://pypi.org/project/packaging/23.2/)
 - [pandas: 2.1.3](https://pypi.org/project/pandas/2.1.3/)

--- a/v2/requirements.in
+++ b/v2/requirements.in
@@ -7,7 +7,6 @@ jupyterlab
 jupytext
 bash_kernel
 nbval
-opensafely-matching
 
 # Commonly-used packages provided in base docker image
 pandas

--- a/v2/requirements.txt
+++ b/v2/requirements.txt
@@ -256,8 +256,6 @@ numpy==1.26.2
     #   seaborn
 opensafely-cohort-extractor==1.90.0
     # via -r v2/requirements.in
-opensafely-matching==0.2.0
-    # via -r v2/requirements.in
 overrides==7.4.0
     # via jupyter-server
 packaging==23.2
@@ -278,7 +276,6 @@ pandas==2.1.3
     #   formulaic
     #   lifelines
     #   opensafely-cohort-extractor
-    #   opensafely-matching
     #   seaborn
     #   upsetplot
 pandocfilters==1.5.0


### PR DESCRIPTION
It previously had opensafely-matching v0.2.0, which doesn't work with the version of pandas included in the v2 image, so no-one could have used it anyway.

matching is now a reusable action, which will be the recommended way to use it in an opensafely study.