### PR TITLE
Remove dependabot pip config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-name: "opensafely-cohort-extractor"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
It was only there for cohort-extractor, which we don't need to update anymore, and it's now failing because the .python-version in this repo is too old. We also remove the .python-version file, because it was only there for dependabot
( see https://github.com/opensafely-core/python-docker/commit/22cc2c99a99a28ae37e9b58f849004b479f682b2)