### PR TITLE
Fix broken CI tests

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -15,7 +15,7 @@ jobs:
     # publish the exact images that were built and tested.
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: "opensafely-core/setup-action@v1"
       with:
           install-just: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         version: [v1, v2]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: "opensafely-core/setup-action@v1"
       with:
           install-just: true
@@ -23,7 +23,7 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: "opensafely-core/setup-action@v1"
       with:
           install-just: true


### PR DESCRIPTION
Currently tests are failing on #128 . 
~~The error encountered resembles some issues we had with r-docker where the `UBUNTU_PRO_TOKEN` was not provided to the CI tests and caused them to fail.
To verify the issue, first use this PR to run the tests on an empty commit on top of `main` - if the above hypothesis is correct, the tests would fail, and we can adapt this PR to add the token and wiring needed.~~

The tests are actually passing on this PR, even with the changes in #128. This might be a [GHA permissions](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1769612163630239?thread_ts=1769610989.512649&channel=C069YDR4NCA&message_ts=1769612163.630239) thing - will run the dependabot PR with my permissions.